### PR TITLE
Add missing colon

### DIFF
--- a/src/content/1/en/part1d.md
+++ b/src/content/1/en/part1d.md
@@ -1163,7 +1163,7 @@ Copilot is also useful in error situations, by copying the error message into Co
 
 ![copilot explaining the error and suggesting a fix](../../images/1/gpt5.png)
 
-Copilot's chat also enables the creation of larger set of functionality
+Copilot's chat also enables the creation of larger set of functionality:
 
 ![copilot creating a login component on request](../../images/1/gpt6.png)
 


### PR DESCRIPTION
There is no colon before an embedded picture following a description of what is in there. In the description followed by a picture above, there is a colon, so it is probably missing here. 